### PR TITLE
Filter the tags archive to the clicked tag

### DIFF
--- a/_pages/tag-archive.html
+++ b/_pages/tag-archive.html
@@ -8,10 +8,74 @@ author_profile: true
 {% include base_path %}
 {% include group-by-array collection=site.posts field="tags" %}
 
+<nav class="taxonomy__index" aria-label="Filter posts by tag">
+  <a href="{{ base_path }}/tags/" class="page__taxonomy-item taxonomy__filter" data-tag-filter="">All tags</a>
+  {% for tag in group_names %}
+    <a href="{{ base_path }}/tags/#{{ tag | slugify }}" class="page__taxonomy-item taxonomy__filter" data-tag-filter="{{ tag | slugify }}" rel="tag">{{ tag }} <span class="taxonomy__count">{{ group_items[forloop.index0] | size }}</span></a>
+  {% endfor %}
+</nav>
+
+<p class="taxonomy__status" id="tag-filter-status" hidden>
+  Showing posts tagged <strong id="tag-filter-name"></strong>.
+  <a href="{{ base_path }}/tags/" id="tag-filter-clear">Show all tags</a>
+</p>
+
 {% for tag in group_names %}
   {% assign posts = group_items[forloop.index0] %}
-  <h2 id="{{ tag | slugify }}" class="archive__subtitle">{{ tag }}</h2>
-  {% for post in posts %}
-    {% include archive-single.html %}
-  {% endfor %}
+  <section class="taxonomy__section" data-tag-section="{{ tag | slugify }}">
+    <h2 id="{{ tag | slugify }}" class="archive__subtitle">{{ tag }}</h2>
+    {% for post in posts %}
+      {% include archive-single.html %}
+    {% endfor %}
+  </section>
 {% endfor %}
+
+<script>
+  (function () {
+    var sections = document.querySelectorAll('[data-tag-section]');
+    var filters = document.querySelectorAll('[data-tag-filter]');
+    var status = document.getElementById('tag-filter-status');
+    var statusName = document.getElementById('tag-filter-name');
+
+    function applyFilter(scrollToTop) {
+      var slug = (window.location.hash || '').replace(/^#/, '').toLowerCase();
+      var matched = null;
+
+      for (var i = 0; i < sections.length; i++) {
+        if (sections[i].getAttribute('data-tag-section') === slug) {
+          matched = sections[i];
+          break;
+        }
+      }
+
+      // Empty or unknown hash falls through to showing every section.
+      for (var j = 0; j < sections.length; j++) {
+        sections[j].hidden = matched ? sections[j] !== matched : false;
+      }
+
+      for (var k = 0; k < filters.length; k++) {
+        var filter = filters[k];
+        var active = matched
+          ? filter.getAttribute('data-tag-filter') === slug
+          : filter.getAttribute('data-tag-filter') === '';
+        filter.classList.toggle('taxonomy__filter--active', active);
+        if (active) {
+          filter.setAttribute('aria-current', 'true');
+        } else {
+          filter.removeAttribute('aria-current');
+        }
+      }
+
+      if (matched) {
+        statusName.textContent = matched.querySelector('.archive__subtitle').textContent;
+        status.hidden = false;
+        if (scrollToTop) { window.scrollTo(0, 0); }
+      } else {
+        status.hidden = true;
+      }
+    }
+
+    applyFilter(false);
+    window.addEventListener('hashchange', function () { applyFilter(true); });
+  })();
+</script>

--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -281,6 +281,39 @@
   }
 }
 
+/* Tag archive filter bar */
+
+.taxonomy__index {
+  margin-bottom: 1.5em;
+  padding-bottom: 0.5em;
+  border-bottom: 1px solid $border-color;
+}
+
+.taxonomy__filter--active {
+  color: #fff;
+  background-color: $accent;
+  border-color: $accent;
+
+  &:hover {
+    color: #fff;
+  }
+}
+
+.taxonomy__count {
+  font-size: $type-size-7;
+  opacity: 0.7;
+}
+
+.taxonomy__status {
+  margin-bottom: 1.5em;
+  font-size: $type-size-6;
+}
+
+.taxonomy__section[hidden],
+.taxonomy__status[hidden] {
+  display: none;
+}
+
 
 /*
    Comments


### PR DESCRIPTION
Clicking a tag in a post (e.g. `#engineering`) already linked to `/tags/#engineering`, but the archive showed every tag group and just scrolled to a heading. Now the page reads the hash and filters to that tag.

## Changes

- `_pages/tag-archive.html` — each tag group is wrapped in a `<section data-tag-section="…">`, with a filter bar of all tags (with post counts), a "Showing posts tagged X — Show all tags" status line, and a small inline script that hides non-matching sections when the URL has a tag hash.
- `_sass/_page.scss` — styles for the filter bar, the active-tag pill (accent teal), and hidden sections.

`_includes/tag-list.html` is unchanged: it already generates the `/tags/#slug` links the filter reads.

## Behaviour

| URL | Result |
| --- | --- |
| `/tags/` | All tags shown, as before |
| `/tags/#engineering` | Only the engineering group; matching pill highlighted |
| `/tags/#unknown` | Falls back to showing everything |
| Clicking a tag in the filter bar | Switches the filter in place and scrolls to top |

Without JavaScript it degrades to the current behaviour — everything visible, anchor jump still works.

## Testing

No local Jekyll available, so the generated HTML was reproduced as a static mock, served over localhost, and the DOM asserted in four states: on-load filtering, hash change, unknown hash, and cleared hash. All behaved as intended. The Liquid itself is unverified until it builds on Pages.

Not included (tags only, as asked): `/categories/` uses the same pattern and could take the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
